### PR TITLE
Fix Action Node.js version from 16 -> 20 for deprecation problem

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,8 @@ inputs:
     description: URL to png of discord avatar to use. Default is the GitHub monochrome mark cat logo.
     required: false
 runs:
-  using: 'node16'
-  main: 'index.js'
+  using: "node20"
+  main: "index.js"
 branding:
   color: orange
   icon: alert-triangle


### PR DESCRIPTION
Hi! Firstly always thank you for contributing awesome opensource. This pull request is for changing Node.js Version Runtime from 16 to 20. 
<img width="1333" alt="image" src="https://github.com/rjstone/discord-webhook-notify/assets/45956041/b3e74820-b6cd-4d49-8af1-5f73164339e8">
Recently while using your opensource, Github Actions make an [annotation](https://github.com/J-Hoplin/Online-Judge-System/actions/runs/7676784932) of Node.js version 16 has been deprecated, and update to Node.js version 20. So I 
 make pull request after change node.js version 20 and test about it.

Test: https://github.com/J-Hoplin/discord-webhook-notify/actions/runs/7683949657
Test Branch: https://github.com/J-Hoplin/discord-webhook-notify/tree/fix/node-version-upgrade

Thank you and have a nice day!